### PR TITLE
Fix mkdocs build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
-CP3-llbb Analysis Tools documentation, see [https://cp3-llbb.github.io](https://cp3-llbb.github.io)
+# CP3-llbb Analysis Tools documentation: 
+You can find the documentation at: [https://cp3-llbb.github.io](https://cp3-llbb.github.io)

--- a/docs/bamboo.md
+++ b/docs/bamboo.md
@@ -1,0 +1,4 @@
+# Bamboo: A high-level HEP analysis library for ROOT::RDataFrame
+You can find out more about bamboo in the UserGuide: https://bamboo-hep.readthedocs.io/en/latest/. 
+Also feel free to report any issue you encounter in [~bamboo channel](https://mattermost.web.cern.ch/cms-exp/channels/bamboo) on the CERN mattermost, or on [Gitlab](https://gitlab.cern.ch/cms-analysis/general/bamboo/-/issues).
+

--- a/docs/plotit.md
+++ b/docs/plotit.md
@@ -133,9 +133,9 @@ There are also a number of optional arguments that change the behaviour:
 | exclude | string | Regexp allowing to exlude histograms present in the files whose name matches the plot's name |  |
 | x-axis | string | x-axis title | |
 | y-axis | string | y-axis title | `Events` |
-| y-axis-format | formatted string | Overrides plotIt option. | |
+| y-axis-format | formatted string | Overrides plotIt option. | %1% |
 | normalized | bool | Normalize data/each signal/total MC to 1. | `false` |
-| normalizedByBinWidth| bool | The bin contents and errors are divided by the bin width. | `false` |
+| normalizedByBinWidth | bool | The bin contents and errors are divided by the bin width. | `false` |
 | no-data | bool | Do not plot data. | `false` |
 | override | bool | If any plot has this field set to true, only plots which do will be produced. | `false` |
 | log-y | bool | Log-scale on y-axis. Special value: `Both`. | `false` |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ nav:
     - Doxygen: doxyfwk/index.html
   - GridIn: gridin.md
   - plotIt: plotit.md
+  - Bamboo: bamboo.md
 
 # Extensions
 markdown_extensions:
@@ -27,6 +28,9 @@ markdown_extensions:
 
 plugins:
   - markdownextradata
+  - search
+  #  - git-revision-date-localized:
+  #  enable_creation_date: true
   - doxygen:
       tryclone: true
       packages:
@@ -34,16 +38,36 @@ plugins:
             url    : https://github.com/cp3-llbb/Framework.git
             config : docs/doxygen.cfg
 
-# Theming
+# https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/#primary-color
 theme:
-  name: 'material'
+  name: material
   language: 'en'
   palette:
-    primary: 'indigo'
-    accent: 'indigo'
+    - scheme: default
+      primary: deep purple
+      accent: deep purple
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - scheme: slate
+      primary: 'indigo'
+      accent: 'indigo' 
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
   font:
     text: 'Roboto'
     code: 'Roboto Mono'
+  features:
+    - header.autohide
+    - navigation.footer
+    - content.action.edit
+    - content.action.view
+    - content.code.copy
+    - search.highlight
+    - search.share
+    - search.suggest
+    - toc.follow
 
 extra:
   social:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,10 +42,10 @@ plugins:
 theme:
   name: 'material'
   language: 'en'
-    palette:
+  palette:
     - scheme: default
       primary: 'indigo'
-      accent: d'indigo'
+      accent: 'indigo'
       toggle:
         icon: material/weather-night
         name: Switch to dark mode

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,15 +40,9 @@ plugins:
 
 # https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/#primary-color
 theme:
-  name: material
+  name: 'material'
   language: 'en'
   palette:
-    - scheme: default
-      primary: deep purple
-      accent: deep purple
-      toggle:
-        icon: material/weather-night
-        name: Switch to dark mode
     - scheme: slate
       primary: 'indigo'
       accent: 'indigo' 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,10 +42,16 @@ plugins:
 theme:
   name: 'material'
   language: 'en'
-  palette:
+    palette:
+    - scheme: default
+      primary: 'indigo'
+      accent: d'indigo'
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
     - scheme: slate
       primary: 'indigo'
-      accent: 'indigo' 
+      accent: 'indigo'
       toggle:
         icon: material/weather-sunny
         name: Switch to light mode

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ mkdocs-material
 Pygments
 pymdown-extensions
 mkdocs-markdownextradata-plugin
-git+https://github.com/pieterdavid/mkdocs-doxygen-plugin.git#egg=mkdocs-doxygen-plugin
+git+https://github.com/kjaffel/mkdocs-doxygen-plugin.git#egg=mkdocs-doxygen-plugin
+


### PR DESCRIPTION

Hi, 

We have an error when building mkdocs related to the Sequence import from the collections module in Python: see [here](https://github.com/cp3-llbb/cp3-llbb.github.io/pull/6/checks).
In Python >= 3.10, `Sequence` and other abstract base classes (ABCs) were moved from `collections` to `collections.abc`.
To fix this issue, I updated Pieter code : https://github.com/kjaffel/mkdocs-doxygen-plugin. 
So [requirements.txt](https://github.com/cp3-llbb/cp3-llbb.github.io/blob/source/requirements.txt) now point to my [fork](git+https://github.com/kjaffel/mkdocs-doxygen-plugin.git) instead, in order to pick up these changes. 